### PR TITLE
Player Position Adjustments

### DIFF
--- a/src/Player.js
+++ b/src/Player.js
@@ -202,6 +202,12 @@ class Player extends PIXI.Sprite {
 
         this.destination = null;
 
+        this.anchor.set(0.5, 0.5);
+
+        this.hitArea = new PIXI.Polygon([
+            0,0, 0,1, 1,1, 1,0
+        ]);
+
         this.applyUpgrades();
 
         this.currentDelay = 0;
@@ -227,12 +233,12 @@ class Player extends PIXI.Sprite {
 
     move(frameDelta) {
         if (this.destination !== null) {
-            let pX = this.x + this.width / 2;
-            let pY = this.y + this.height / 2;
+            let pX = this.x;
+            let pY = this.y;
 
             // To prevent costly calculations in case the player is already very close to the cursor, start with a check
             if (Math.abs(pX - this.destination.x / arcInc.pixiApp.stage.scale.x) < this.stats.effectiveMovementSpeed && Math.abs(pY - this.destination.y / arcInc.pixiApp.stage.scale.y) < this.stats.effectiveMovementSpeed) {
-                this.position.set(this.destination.x / arcInc.pixiApp.stage.scale.x - this.width / 2, this.destination.y / arcInc.pixiApp.stage.scale.y - this.height / 2);
+                this.position.set(this.destination.x / arcInc.pixiApp.stage.scale.x, this.destination.y / arcInc.pixiApp.stage.scale.y);
                 this.destination = null;
             } else {
 

--- a/src/abilities/BlackHole.js
+++ b/src/abilities/BlackHole.js
@@ -22,11 +22,12 @@ class BlackHole extends Ability {
         let playerContainer = arcInc.objectStore.get('playerContainer');
         let player = arcInc.objectStore.get('player');
         let blackHole= new PIXI.Sprite(PIXI.Loader.shared.resources["assets/sprites/BlackHole.png"].texture);
+
         blackHole.remainingFrames = 450;
         playerContainer.addChild(blackHole);
 
-        blackHole.x = player.x + player.width/2 - blackHole.width/2;
-        blackHole.y = player.y + player.height/2 - blackHole.height/2 - 250;
+        blackHole.x = player.x;
+        blackHole.y = player.y - 250;
         blackHole.anchor.set(0.5, 0.5);
         this.blackHoles.push(blackHole);
     }

--- a/src/abilities/TacticalNuke.js
+++ b/src/abilities/TacticalNuke.js
@@ -23,10 +23,11 @@ class TacticalNuke extends Ability {
         let player = arcInc.objectStore.get('player');
         let tacticalNuke = new PIXI.Sprite(PIXI.Loader.shared.resources["assets/sprites/TacticalNuke.png"].texture);
         tacticalNuke.scale.set(0.5);
+        tacticalNuke.anchor.set(0.5, 0.5);
         playerContainer.addChild(tacticalNuke);
 
-        tacticalNuke.x = player.x + player.width/2 - tacticalNuke.width/2;
-        tacticalNuke.y = player.y + player.height/2 - tacticalNuke.height/2;
+        tacticalNuke.x = player.x;
+        tacticalNuke.y = player.y - player.height;
         this.tacticalNukes.push(tacticalNuke);
 
     }

--- a/src/scenes/MainScene.js
+++ b/src/scenes/MainScene.js
@@ -177,8 +177,8 @@ class MainScene extends Scene{
             this.pixiApp.screen.width/this.pixiApp.stage.scale.x,
             this.pixiApp.screen.height/this.pixiApp.stage.scale.y);
         player.scale.set(0.5);
-        player.x = this.pixiApp.screen.width/this.pixiApp.stage.scale.x/2 - player.width/2;
-        player.y = this.pixiApp.screen.height/this.pixiApp.stage.scale.y - player.height;
+        player.x = this.pixiApp.screen.width/this.pixiApp.stage.scale.x/2;
+        player.y = this.pixiApp.screen.height/this.pixiApp.stage.scale.y - player.height * 2.5;
         playerContainer.addChild(player);
         arcInc.objectStore.put('player', player);
     }


### PR DESCRIPTION
- Adjusts player's starting position so they start above the health bar
Before:
![Current Starting Position](https://i.imgur.com/VkVdmwO.png)
After:
![Proposed Starting Position](https://i.imgur.com/qDNOlox.png)

- Improved targeting by the suicide bombers
Before:
![Current Targeting](https://i.imgur.com/m29O9fm.gif)
After:
![Proposed Targeting](https://i.imgur.com/bVSLGaM.gif)

- Adjusted spawn location for nuke
Before:
![Current Nuke Spawn](https://i.imgur.com/Ip3yCfS.gif)
After:
![Proposed Nuke Spawn](https://i.imgur.com/uIlBNPo.gif)
